### PR TITLE
タグ push 時に npm へ自動公開する GitHub Actions を追加

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,36 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+      - run: npm test
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- `v*` タグの push をトリガーに npm へパッケージを公開する `publish` ワークフローを追加
- 公開前に `npm test`（lint 含む）とタグ/`package.json` バージョンの一致確認を実行
- npm Trusted Publishing (OIDC) と `--provenance` による公開に対応

## Test plan

- [ ] PR マージ後、npm の Trusted Publisher に `publish.yaml` / `masaminh/lighten_stack` を登録
- [ ] `package.json` の version を更新して `v*` タグを push し、ワークフローが成功することを確認
- [ ] `npm view @masaminh/lighten_stack` で新バージョンが公開されていることを確認
- [ ] バージョン不一致タグでワークフローが fail することを確認


Made with [Cursor](https://cursor.com)