### PR TITLE
publish ワークフローで npm をアップグレード

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,9 @@ jobs:
           node-version-file: '.tool-versions'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - run: npm ci
       - run: npm test
 


### PR DESCRIPTION
## Summary
- publish ワークフローに `npm install -g npm@latest` を追加
- Trusted Publishing（OIDC）には npm CLI 11.5.1 以上が必要だが、Node 22 同梱の npm 10.x では 404 エラーになるため対応

## Test plan
- [ ] CI（test ワークフロー）が成功すること
- [ ] マージ後、publish ワークフローを再実行して npm 公開が成功すること

Made with [Cursor](https://cursor.com)