### PR TITLE
Dependabot 設定をグルーピングと GitHub Actions 更新に拡張

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,45 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- npm の Dependabot 更新を `dev-dependencies` / `production-dependencies` の 2 グループに分割（minor/patch のみグループ化、major は個別 PR）
- 毎週月曜 09:00（Asia/Tokyo）のスケジュール、`dependencies` ラベル、`open-pull-requests-limit: 5` を追加
- `github-actions` エコシステムの更新を追加し、Actions も weekly で minor/patch をグループ更新

## Test plan
- [ ] main マージ後、次回 Dependabot 実行時に `dev-dependencies` / `production-dependencies` / `github-actions` グループの PR が作成されることを確認
- [ ] 作成された PR に `dependencies` ラベルが付与されることを確認
- [ ] major 更新は引き続き個別 PR として作成されることを確認


Made with [Cursor](https://cursor.com)